### PR TITLE
Remove dependency on 'future' module

### DIFF
--- a/osm_downloader.py
+++ b/osm_downloader.py
@@ -22,8 +22,6 @@
 """
 
 #Another way to do the Job with OVERPASS
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import urllib.request, urllib.error, urllib.parse
 from qgis.PyQt.QtCore import QObject, pyqtSignal, QSettings, pyqtSlot, QThreadPool, QRunnable

--- a/plugin_upload.py
+++ b/plugin_upload.py
@@ -6,8 +6,6 @@
 """
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import input
 import sys
 import getpass

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 """Tests QGIS plugin init."""
 
-from future import standard_library
-standard_library.install_aliases()
 __author__ = 'Tim Sutton <tim@linfiniti.com>'
 __revision__ = '$Format:%H$'
 __date__ = '17/10/2010'


### PR DESCRIPTION
There are [issues](https://bbs.archlinux.org/viewtopic.php?id=302235) with installing the `future` module since it relies on `lib2to3`, which is deprecated. The module is only for Python 2 support (which should be unnecessary nowadays) so I have removed the lines in which it is imported.